### PR TITLE
Revert malformed � character

### DIFF
--- a/applywdac.ps1
+++ b/applywdac.ps1
@@ -72,7 +72,7 @@ function ApplyWDACPolicy {
       $policybin = "SiPolicy_Audit.p7b"
     }
 
-    $binpolicyzip = [IO.Path]::GetTempFileName() | Rename-Item -NewName { $_ -replace 'tmp$', 'zip' } �PassThru
+    $binpolicyzip = [IO.Path]::GetTempFileName() | Rename-Item -NewName { $_ -replace 'tmp$', 'zip' } -PassThru
     Write-Output "Downloading https://aka.ms/VulnerableDriverBlockList"
     Invoke-WebRequest https://aka.ms/VulnerableDriverBlockList -UseBasicParsing -OutFile $binpolicyzip
     $zipFile = [IO.Compression.ZipFile]::OpenRead($binpolicyzip)


### PR DESCRIPTION
Hello,

Thanks for making this nice tool. 

Looks like a rogue `�` character managed to inadvertently sneak into the [previous commit](https://github.com/wdormann/applywdac/commit/e2170548afc4d7a5ae83b8955e2aedfa470e75e1#diff-630edf12345a8291576f03db77ddb8e5b24be769df6f420fdc588c609ead81ceL69-R75). This produced the following output on Windows Server 2019.

When I replaced the `�` with `-` it ran normally.

```text
PS C:\Users\Ben\Downloads> .\applywdac.ps1 -auto -enforce
Rename-Item : Cannot rename because item at '?PassThru' does not exist.
At C:\Users\Ben\Downloads\applywdac.ps1:75 char:52
+ ... ileName() | Rename-Item -NewName { $_ -replace 'tmp$', 'zip' } ?PassT ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [Rename-Item], PSInvalidOperationException
    + FullyQualifiedErrorId : InvalidOperation,Microsoft.PowerShell.Commands.RenameItemCommand

Downloading https://aka.ms/VulnerableDriverBlockList


StatusCode        : 200
StatusDescription : OK
Content           : {80, 75, 3, 4...}
RawContent        : HTTP/1.1 200 OK
                    Content-MD5: VUUE6eE8s3qHa+WfsRDPaQ==
                    Connection: keep-alive
                    Accept-Ranges: bytes
                    Content-Length: 98278
                    Content-Type: application/octet-stream
                    Date: Tue, 20 Dec 2022 22:06:07 GMT...
Headers           : {[Content-MD5, VUUE6eE8s3qHa+WfsRDPaQ==], [Connection, keep-alive], [Accept-Ranges, bytes],
                    [Content-Length, 98278]...}
RawContentLength  : 98278

Exception calling "OpenRead" with "1" argument(s): "Path cannot be null.
Parameter name: path"
At C:\Users\Ben\Downloads\applywdac.ps1:78 char:5
+     $zipFile = [IO.Compression.ZipFile]::OpenRead($binpolicyzip)
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : ArgumentNullException

Extracting SiPolicy_Enforced.p7b to C:\Windows\system32\CodeIntegrity\SiPolicy.p7b
Get-ChildItem : Cannot find path 'C:\Windows\system32\CodeIntegrity\SiPolicy.p7b' because it does not exist.
At C:\Users\Ben\Downloads\applywdac.ps1:81 char:5
+     Get-ChildItem "$env:windir\system32\CodeIntegrity\SiPolicy.p7b"
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (C:\Windows\syst...ty\SiPolicy.p7b:String) [Get-ChildItem], ItemNotFound
   Exception
    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.GetChildItemCommand


Please Reboot to apply changes
```

Thanks!